### PR TITLE
Fixed savng functionality

### DIFF
--- a/views/classes/index.html
+++ b/views/classes/index.html
@@ -84,7 +84,7 @@
      colHeaders: false,
      rowHeaders: false,
      contextMenu: true,
-     /*
+
      afterChange: function(change, source) {
          if(source === "loadData") {
              return;
@@ -102,7 +102,6 @@
              }
          });
      }
-     */
  };
  
  function set_visible_columns(row) {


### PR DESCRIPTION
Two lessons from this:

1. jQuery.ajax accepts a javascript array. Just use that. It's easiest.
2. The action needs to return a json object, even if it's empty. If it doesn't, I think web2py returns a default html page. The jQuery json parser chokes on it.